### PR TITLE
[ENG-722] Cost Model Factories and deploy script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
 # Compiler files
 cache/
 out/
-
-# Ignores development broadcast logs
-!/broadcast
-/broadcast/*
-/broadcast/*/31337/

--- a/script/DeployModelFactories.s.sol
+++ b/script/DeployModelFactories.s.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Unlicensed
+pragma solidity 0.8.15;
+
+import "forge-std/Script.sol";
+import "src/CostModelJumpRateFactory.sol";
+import "src/DecayModelConstantFactory.sol";
+import "src/DripModelConstantFactory.sol";
+
+/**
+  * @notice Purpose: Local deploy, testing, and production.
+  *
+  * This script deploys the Model Factory contracts.
+  * Before executing, the configuration section in the script should be updated.
+  *
+  * To run this script:
+  *
+  * ```sh
+  * # Start anvil, forking from the current state of the desired chain.
+  * anvil --fork-url $OPTIMISM_RPC_URL
+  *
+  * # In a separate terminal, perform a dry run of the script.
+  * forge script script/DeployModelFactories.s.sol \
+  *   --rpc-url "http://127.0.0.1:8545" \
+  *   -vvvv
+  *
+  * # Or, to broadcast a transaction.
+  * forge script script/DeployModelFactories.s.sol \
+  *   --rpc-url "http://127.0.0.1:8545" \
+  *   --private-key $OWNER_PRIVATE_KEY \
+  *   --broadcast \
+  *   -vvvv
+  * ```
+ */
+contract DeployModelFactories is Script {
+
+  /// @notice Deploys all the Model Factory contracts
+  function run() public {
+    console2.log("Deploying Cozy V2 Model Factories...");
+
+    console2.log("  Deploying CostModelJumpRateFactory...");
+    vm.broadcast();
+    address costModelFactory = address(new CostModelJumpRateFactory());
+    console2.log("  CostModelJumpRateFactory deployed,", costModelFactory);
+
+    console2.log("  Deploying DecayModelConstantFactory...");
+    vm.broadcast();
+    address decayModelFactory = address(new DecayModelConstantFactory());
+    console2.log("  DecayModelConstantFactory deployed,", decayModelFactory);
+
+    console2.log("  Deploying DripModelConstantFactory...");
+    vm.broadcast();
+    address dripRateFactory = address(new DripModelConstantFactory());
+    console2.log("  DripModelConstantFactory deployed,", dripRateFactory);
+
+    console2.log("Finished deploying Cozy V2 Model Factories");
+  }
+}

--- a/src/CostModelJumpRateFactory.sol
+++ b/src/CostModelJumpRateFactory.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Unlicensed
+pragma solidity 0.8.15;
+
+import "src/CostModelJumpRate.sol";
+import "src/abstract/BaseModelFactory.sol";
+import "src/lib/Create2.sol";
+
+/**
+ * @notice The factory for deploying a CostModelJumpRate contract.
+ */
+contract CostModelJumpRateFactory is BaseModelFactory {
+
+  /// @notice Event that indicates a CostModelJumpRate has been deployed.
+  event DeployedCostModelJumpRate(
+    address indexed costModel,
+    uint256 kink,
+    uint256 costFactorAtZeroUtilization,
+    uint256 costFactorAtKinkUtilization,
+    uint256 costFactorAtFullUtilization,
+    uint256 cancellationPenalty
+  );
+
+  /// @notice Deploys a CostModelJumpRate contract and emits a 
+  /// DeployedCostModelJumpRate event that indicates what the params from the deployment are. 
+  /// This address is then cached inside the isDeployed mapping. See CostModelJumpRate 
+  /// constructor for more info about the input parameters.
+  /// @return _model which has an address that is deterministic with the input parameters.
+  function deployModel(
+    uint256 _kink,
+    uint256 _costFactorAtZeroUtilization,
+    uint256 _costFactorAtKinkUtilization,
+    uint256 _costFactorAtFullUtilization,
+    uint256 _cancellationPenalty
+  ) external returns (CostModelJumpRate _model) {
+
+    _model = new CostModelJumpRate{salt: DEFAULT_SALT}(
+      _kink,
+      _costFactorAtZeroUtilization,
+      _costFactorAtKinkUtilization,
+      _costFactorAtFullUtilization,
+      _cancellationPenalty
+    );
+    isDeployed[address(_model)] = true;
+
+    emit DeployedCostModelJumpRate(
+      address(_model),
+      _kink,
+      _costFactorAtZeroUtilization,
+      _costFactorAtKinkUtilization,
+      _costFactorAtFullUtilization,
+      _cancellationPenalty
+    );
+  }
+
+  /// @return The address where the model is deployed, or address(0) if it isn't deployed.
+  function getModel(
+    uint256 _kink,
+    uint256 _costFactorAtZeroUtilization,
+    uint256 _costFactorAtKinkUtilization,
+    uint256 _costFactorAtFullUtilization,
+    uint256 _cancellationPenalty
+  ) external view returns (address) {
+    bytes memory _costModelConstructorArgs = abi.encode(
+      _kink,
+      _costFactorAtZeroUtilization,
+      _costFactorAtKinkUtilization,
+      _costFactorAtFullUtilization,
+      _cancellationPenalty
+    );
+
+    address _addr = Create2.computeCreate2Address(
+      type(CostModelJumpRate).creationCode, 
+      _costModelConstructorArgs,
+      address(this),
+      DEFAULT_SALT
+    );
+
+    return isDeployed[_addr] ? _addr : address(0);
+  }
+}

--- a/src/DecayModelConstantFactory.sol
+++ b/src/DecayModelConstantFactory.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Unlicensed
+pragma solidity 0.8.15;
+
+import "src/DecayModelConstant.sol";
+import "src/abstract/BaseModelFactory.sol";
+import "src/lib/Create2.sol";
+
+/**
+ * @notice The factory for deploying a DecayModelConstant contract.
+ */
+contract DecayModelConstantFactory is BaseModelFactory {
+
+  /// @notice Event that indicates a DecayModelConstant has been deployed.
+  event DeployedDecayModelConstant(
+    address indexed costModel,
+    uint256 decayRatePerSecond
+  );
+
+  /// @notice Deploys a DecayModelConstant contract and emits a DeployedDecayModelConstant event that 
+  /// indicates what the params from the deployment are. This address is then cached inside the 
+  /// isDeployed mapping. 
+  /// @return _model which has an address that is deterministic with the input _decayRatePerSecond.
+  function deployModel(uint256 _decayRatePerSecond) external returns (DecayModelConstant _model) {
+
+    _model = new DecayModelConstant{salt: DEFAULT_SALT}(_decayRatePerSecond);
+    isDeployed[address(_model)] = true;
+
+    emit DeployedDecayModelConstant(address(_model), _decayRatePerSecond);
+  }
+
+  /// @return The address where the model is deployed, or address(0) if it isn't deployed.
+  function getModel(uint256 _decayRatePerSecond) external view returns (address) {
+    bytes memory _decayModelConstructorArgs = abi.encode(
+      _decayRatePerSecond
+    );
+
+    address _addr = Create2.computeCreate2Address(
+      type(DecayModelConstant).creationCode, 
+      _decayModelConstructorArgs,
+      address(this),
+      DEFAULT_SALT
+    );
+
+    return isDeployed[_addr] ? _addr : address(0);
+  }
+}

--- a/src/DripModelConstantFactory.sol
+++ b/src/DripModelConstantFactory.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Unlicensed
+pragma solidity 0.8.15;
+
+import "src/DripModelConstant.sol";
+import "src/abstract/BaseModelFactory.sol";
+import "src/lib/Create2.sol";
+
+/**
+ * @notice The factory for deploying a DripModelConstant contract.
+ */
+contract DripModelConstantFactory is BaseModelFactory {
+
+  /// @notice Event that indicates a DripModelConstant has been deployed.
+  event DeployedDripModelConstant(
+    address indexed costModel,
+    uint256 dripRatePerSecond
+  );
+
+  /// @notice Deploys a DripModelConstant contract and emits a DeployedDripModelConstant event 
+  /// that indicates what the params from the deployment are. This address is then cached inside 
+  /// the isDeployed mapping. 
+  /// @return _model which has an address that is deterministic with the input _dripRatePerSecond.
+  function deployModel(uint256 _dripRatePerSecond) external returns (DripModelConstant _model) {
+
+    _model = new DripModelConstant{salt: DEFAULT_SALT}(_dripRatePerSecond);
+    isDeployed[address(_model)] = true;
+
+    emit DeployedDripModelConstant(address(_model), _dripRatePerSecond);
+  }
+
+  /// @return The address where the model is deployed, or address(0) if it isn't deployed.
+  function getModel(uint256 _dripRatePerSecond) external view returns (address) {
+    bytes memory _dripModelConstructorArgs = abi.encode(
+      _dripRatePerSecond
+    );
+
+    address _addr = Create2.computeCreate2Address(
+      type(DripModelConstant).creationCode, 
+      _dripModelConstructorArgs,
+      address(this),
+      DEFAULT_SALT
+    );
+
+    return isDeployed[_addr] ? _addr : address(0);
+  }
+}

--- a/src/abstract/BaseModelFactory.sol
+++ b/src/abstract/BaseModelFactory.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Unlicensed
+pragma solidity 0.8.15;
+
+/**
+ * @notice Base class for model factories.
+ */
+abstract contract BaseModelFactory {
+
+  /// @dev We have a default salt for computing the resulting address of a create2 call. 
+  /// This is ok due to a combination of two reasons: 
+  /// (1) for a given configuration, only a single instance of that model needs to exist, and
+  /// (2) models have constructor args and therefore each configuration has a different initcode hash. 
+  /// As a result, the differing initcode is sufficient to make sure each model 
+  /// is at a unique address and the salt is unnecessary here.
+  bytes32 internal constant DEFAULT_SALT = keccak256("0");
+
+  /// @notice The set of all Models that have been deployed from this factory. 
+  /// The created Models should always have addresses that are deterministic with
+  /// the model creation parameters, so if the model exists then it will be in this mapping. 
+  /// Use getModel(/*params*/) to check if the model exists in the mapping and return 
+  /// the address directly.
+  mapping (address => bool) public isDeployed;
+}

--- a/src/lib/Create2.sol
+++ b/src/lib/Create2.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Unlicensed
+pragma solidity 0.8.15;
+
+library Create2 {
+  /// @notice Computes the address that would result from a CREATE2 call for a contract according
+  /// to the spec in https://eips.ethereum.org/EIPS/eip-1014
+  /// @return The CREATE2 address as computed using the params.
+  /// @param _creationCode The creation code bytes of the specified contract.
+  /// @param _constructorArgs The abi encoded constructor args.
+  /// @param _deployer The address of the deployer of the contract.
+  /// @param _salt The salt used to compute the create2 address.
+  function computeCreate2Address(    
+    bytes memory _creationCode,
+    bytes memory _constructorArgs,
+    address _deployer,
+    bytes32 _salt
+  ) internal pure returns (address) {
+    bytes32 _bytecodeHash = keccak256(bytes.concat(_creationCode, _constructorArgs));
+    bytes32 _data = keccak256(bytes.concat(bytes1(0xff), bytes20(_deployer), _salt, _bytecodeHash));
+    return address(uint160(uint256(_data)));
+  }
+}

--- a/test/CostModelJumpRateFactory.t.sol
+++ b/test/CostModelJumpRateFactory.t.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Unlicensed
+pragma solidity 0.8.15;
+
+import "src/CostModelJumpRateFactory.sol";
+import "src/lib/Create2.sol";
+import "solmate/utils/FixedPointMathLib.sol";
+import "forge-std/Test.sol";
+
+contract CostModelJumpRateFactoryTest is Test, CostModelJumpRateFactory {
+
+  CostModelJumpRateFactory factory;
+
+  function setUp() public {
+    factory = new CostModelJumpRateFactory();
+  }
+
+  function test_deployModelAndVerifyAvailable() public {
+    testFuzz_deployModelAndVerifyAvailable(
+      0.8e18, // kink at 80% utilization
+      0.0e18, // 0% fee at no utilization
+      0.2e18, // 20% fee at kink utilization
+      0.5e18, // 50% fee at full utilization
+      0.1e18 // charge a 10% penalty to cancel
+    );
+  }
+
+  function testFuzz_deployModelAndVerifyAvailable(
+    uint256 _kink,
+    uint256 _costFactorAtZeroUtilization,
+    uint256 _costFactorAtKinkUtilization,
+    uint256 _costFactorAtFullUtilization,
+    uint256 _cancellationPenalty
+  ) public {
+    _kink = bound(_kink, 0, FixedPointMathLib.WAD);
+    _costFactorAtZeroUtilization = bound(_costFactorAtZeroUtilization, 0, FixedPointMathLib.WAD);
+    _costFactorAtKinkUtilization = bound(_costFactorAtKinkUtilization, 0, FixedPointMathLib.WAD);
+    _costFactorAtFullUtilization = bound(_costFactorAtFullUtilization, 0, FixedPointMathLib.WAD);
+    _cancellationPenalty = bound(_cancellationPenalty, 0, FixedPointMathLib.WAD);
+
+    address _existingAddress = factory.getModel(     
+      _kink,
+      _costFactorAtZeroUtilization,
+      _costFactorAtKinkUtilization,
+      _costFactorAtFullUtilization,
+      _cancellationPenalty
+    );
+    assertEq(_existingAddress, address(0));
+
+    bytes memory _costModelConstructorArgs = abi.encode(
+      _kink,
+      _costFactorAtZeroUtilization,
+      _costFactorAtKinkUtilization,
+      _costFactorAtFullUtilization,
+      _cancellationPenalty
+    );
+
+    address _addr = Create2.computeCreate2Address(
+      type(CostModelJumpRate).creationCode, 
+      _costModelConstructorArgs,
+      address(factory),
+      keccak256("0")
+    );
+
+    vm.expectEmit(true, false, false, true);
+    emit DeployedCostModelJumpRate(
+      _addr, 
+      _kink,
+      _costFactorAtZeroUtilization,
+      _costFactorAtKinkUtilization,
+      _costFactorAtFullUtilization,
+      _cancellationPenalty
+    );
+
+    address _result = address(
+      factory.deployModel(      
+        _kink,
+        _costFactorAtZeroUtilization,
+        _costFactorAtKinkUtilization,
+        _costFactorAtFullUtilization,
+        _cancellationPenalty
+      )
+    );
+    _existingAddress = factory.getModel(     
+      _kink,
+      _costFactorAtZeroUtilization,
+      _costFactorAtKinkUtilization,
+      _costFactorAtFullUtilization,
+      _cancellationPenalty
+    );
+    assertEq(_result, _existingAddress);
+
+    // Trying to deploy again should result in revert
+    vm.expectRevert();
+    factory.deployModel(      
+      _kink,
+      _costFactorAtZeroUtilization,
+      _costFactorAtKinkUtilization,
+      _costFactorAtFullUtilization,
+      _cancellationPenalty
+    );
+  }
+}

--- a/test/DecayModelConstantFactory.t.sol
+++ b/test/DecayModelConstantFactory.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Unlicensed
+pragma solidity 0.8.15;
+
+import "src/DecayModelConstantFactory.sol";
+import "src/lib/Create2.sol";
+import "forge-std/Test.sol";
+
+contract DecayModelConstantFactoryTest is Test, DecayModelConstantFactory {
+
+  DecayModelConstantFactory factory;
+
+  function setUp() public {
+    factory = new DecayModelConstantFactory();
+  }
+
+  function test_deployModelAndVerifyAvailable() public {
+    testFuzz_deployModelAndVerifyAvailable(100);
+  }
+
+  function testFuzz_deployModelAndVerifyAvailable(uint256 _decayRatePerSecond) public {
+    _decayRatePerSecond = bound(_decayRatePerSecond, 0, type(uint256).max);
+
+    assertEq(factory.getModel(_decayRatePerSecond), address(0));
+
+    bytes memory _decayModelConstructorArgs = abi.encode(_decayRatePerSecond);
+
+    address _addr = Create2.computeCreate2Address(
+      type(DecayModelConstant).creationCode, 
+      _decayModelConstructorArgs,
+      address(factory),
+      keccak256("0")
+    );
+
+    vm.expectEmit(true, false, false, true);
+    emit DeployedDecayModelConstant(_addr, _decayRatePerSecond);
+    address _result = address(factory.deployModel(_decayRatePerSecond));
+    assertEq(_result, factory.getModel(_decayRatePerSecond));
+
+    // Trying to deploy again should result in revert
+    vm.expectRevert();
+    factory.deployModel(_decayRatePerSecond);
+  }
+}

--- a/test/DripModelConstantFactory.t.sol
+++ b/test/DripModelConstantFactory.t.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Unlicensed
+pragma solidity 0.8.15;
+
+import "src/DripModelConstantFactory.sol";
+import "src/lib/Create2.sol";
+import "forge-std/Test.sol";
+
+contract DripModelConstantFactoryTest is Test, DripModelConstantFactory {
+
+  DripModelConstantFactory factory;
+
+  function setUp() public {
+    factory = new DripModelConstantFactory();
+  }
+
+  function test_deployModelAndVerifyAvailable() public {
+    testFuzz_deployModelAndVerifyAvailable(100);
+  }
+
+  function testFuzz_deployModelAndVerifyAvailable(uint256 _dripRatePerSecond) public {
+    _dripRatePerSecond = bound(_dripRatePerSecond, 0, type(uint256).max);
+
+    assertEq(factory.getModel(_dripRatePerSecond), address(0));
+
+    bytes memory _dripModelConstructorArgs = abi.encode(
+      _dripRatePerSecond
+    );
+
+    address _addr = Create2.computeCreate2Address(
+      type(DripModelConstant).creationCode, 
+      _dripModelConstructorArgs,
+      address(factory),
+      keccak256("0")
+    );
+
+    vm.expectEmit(true, false, false, true);
+    emit DeployedDripModelConstant(_addr, _dripRatePerSecond);
+    address _result = address(factory.deployModel(_dripRatePerSecond));
+    assertEq(_result, factory.getModel(_dripRatePerSecond));
+
+    // Trying to deploy again should result in revert
+    vm.expectRevert();
+    factory.deployModel(_dripRatePerSecond);
+  }
+}


### PR DESCRIPTION
This PR adds factory contracts and tests for the following contracts:
* CostModelJumpRate
* DecayModelConstant
* DripModelConstant

It also adds a script for deployment of the added factory contracts.
It seems like we should change the existing deploy scripts for the models to use
the factory contracts, but we can do this once these contracts are deployed to prod. 