### PR TITLE
feat: remove cancellation penalty from jump rate model

### DIFF
--- a/script/DeployCostModelJumpRate.s.sol
+++ b/script/DeployCostModelJumpRate.s.sol
@@ -41,7 +41,6 @@ contract DeployCostModelJumpRate is ScriptUtils {
 
   // Note: The attributes in this struct must be in alphabetical order due to `parseJson` limitations.
   struct CostModelMetadata {
-    uint256 cancellationPenalty; // Penalty to cancel
     uint256 costFactorAtFullUtilization; // Fee at full utilization
     uint256 costFactorAtKinkUtilization; // Fee at kink utilization
     uint256 costFactorAtZeroUtilization; // Fee at no utilization
@@ -67,14 +66,12 @@ contract DeployCostModelJumpRate is ScriptUtils {
     console2.log("    costFactorAtZeroUtilization", _metadata.costFactorAtZeroUtilization);
     console2.log("    costFactorAtKinkUtilization", _metadata.costFactorAtKinkUtilization);
     console2.log("    costFactorAtFullUtilization", _metadata.costFactorAtFullUtilization);
-    console2.log("    cancellationPenalty", _metadata.cancellationPenalty);
 
     address _availableModel = factory.getModel(
       _metadata.kink,
       _metadata.costFactorAtZeroUtilization,
       _metadata.costFactorAtKinkUtilization,
-      _metadata.costFactorAtFullUtilization,
-      _metadata.cancellationPenalty
+      _metadata.costFactorAtFullUtilization
     );
 
     if (_availableModel == address(0)) {
@@ -83,8 +80,7 @@ contract DeployCostModelJumpRate is ScriptUtils {
         _metadata.kink,
         _metadata.costFactorAtZeroUtilization,
         _metadata.costFactorAtKinkUtilization,
-        _metadata.costFactorAtFullUtilization,
-        _metadata.cancellationPenalty
+        _metadata.costFactorAtFullUtilization
       ));
       console2.log("New CostModelJumpRate deployed");
     } else {

--- a/script/input/10/deploy-cost-model-jump-rate-production.json
+++ b/script/input/10/deploy-cost-model-jump-rate-production.json
@@ -1,7 +1,6 @@
 {
   "factory": "0xF6660966f9A20259396d1A1674fC2DD1773a1C73",
   "metadata": {
-    "cancellationPenalty": 100000000000000000,
     "costFactorAtFullUtilization": 500000000000000000,
     "costFactorAtKinkUtilization": 200000000000000000,
     "costFactorAtZeroUtilization": 0,

--- a/script/input/10/deploy-cost-model-jump-rate-test.json
+++ b/script/input/10/deploy-cost-model-jump-rate-test.json
@@ -1,7 +1,6 @@
 {
   "factory": "0xF6660966f9A20259396d1A1674fC2DD1773a1C73",
   "metadata": {
-    "cancellationPenalty": 100000000000000000,
     "costFactorAtFullUtilization": 500000000000000000,
     "costFactorAtKinkUtilization": 200000000000000000,
     "costFactorAtZeroUtilization": 0,

--- a/src/CostModelJumpRateFactory.sol
+++ b/src/CostModelJumpRateFactory.sol
@@ -16,29 +16,26 @@ contract CostModelJumpRateFactory is BaseModelFactory {
     uint256 kink,
     uint256 costFactorAtZeroUtilization,
     uint256 costFactorAtKinkUtilization,
-    uint256 costFactorAtFullUtilization,
-    uint256 cancellationPenalty
+    uint256 costFactorAtFullUtilization
   );
 
-  /// @notice Deploys a CostModelJumpRate contract and emits a 
-  /// DeployedCostModelJumpRate event that indicates what the params from the deployment are. 
-  /// This address is then cached inside the isDeployed mapping. See CostModelJumpRate 
+  /// @notice Deploys a CostModelJumpRate contract and emits a
+  /// DeployedCostModelJumpRate event that indicates what the params from the deployment are.
+  /// This address is then cached inside the isDeployed mapping. See CostModelJumpRate
   /// constructor for more info about the input parameters.
   /// @return _model which has an address that is deterministic with the input parameters.
   function deployModel(
     uint256 _kink,
     uint256 _costFactorAtZeroUtilization,
     uint256 _costFactorAtKinkUtilization,
-    uint256 _costFactorAtFullUtilization,
-    uint256 _cancellationPenalty
+    uint256 _costFactorAtFullUtilization
   ) external returns (CostModelJumpRate _model) {
 
     _model = new CostModelJumpRate{salt: DEFAULT_SALT}(
       _kink,
       _costFactorAtZeroUtilization,
       _costFactorAtKinkUtilization,
-      _costFactorAtFullUtilization,
-      _cancellationPenalty
+      _costFactorAtFullUtilization
     );
     isDeployed[address(_model)] = true;
 
@@ -47,8 +44,7 @@ contract CostModelJumpRateFactory is BaseModelFactory {
       _kink,
       _costFactorAtZeroUtilization,
       _costFactorAtKinkUtilization,
-      _costFactorAtFullUtilization,
-      _cancellationPenalty
+      _costFactorAtFullUtilization
     );
   }
 
@@ -57,19 +53,17 @@ contract CostModelJumpRateFactory is BaseModelFactory {
     uint256 _kink,
     uint256 _costFactorAtZeroUtilization,
     uint256 _costFactorAtKinkUtilization,
-    uint256 _costFactorAtFullUtilization,
-    uint256 _cancellationPenalty
+    uint256 _costFactorAtFullUtilization
   ) external view returns (address) {
     bytes memory _costModelConstructorArgs = abi.encode(
       _kink,
       _costFactorAtZeroUtilization,
       _costFactorAtKinkUtilization,
-      _costFactorAtFullUtilization,
-      _cancellationPenalty
+      _costFactorAtFullUtilization
     );
 
     address _addr = Create2.computeCreate2Address(
-      type(CostModelJumpRate).creationCode, 
+      type(CostModelJumpRate).creationCode,
       _costModelConstructorArgs,
       address(this),
       DEFAULT_SALT

--- a/test/CostModelJumpRateFactory.t.sol
+++ b/test/CostModelJumpRateFactory.t.sol
@@ -19,8 +19,7 @@ contract CostModelJumpRateFactoryTest is Test, CostModelJumpRateFactory {
       0.8e18, // kink at 80% utilization
       0.0e18, // 0% fee at no utilization
       0.2e18, // 20% fee at kink utilization
-      0.5e18, // 50% fee at full utilization
-      0.1e18 // charge a 10% penalty to cancel
+      0.5e18 // 50% fee at full utilization
     );
   }
 
@@ -28,21 +27,18 @@ contract CostModelJumpRateFactoryTest is Test, CostModelJumpRateFactory {
     uint256 _kink,
     uint256 _costFactorAtZeroUtilization,
     uint256 _costFactorAtKinkUtilization,
-    uint256 _costFactorAtFullUtilization,
-    uint256 _cancellationPenalty
+    uint256 _costFactorAtFullUtilization
   ) public {
     _kink = bound(_kink, 0, FixedPointMathLib.WAD);
     _costFactorAtZeroUtilization = bound(_costFactorAtZeroUtilization, 0, FixedPointMathLib.WAD);
     _costFactorAtKinkUtilization = bound(_costFactorAtKinkUtilization, 0, FixedPointMathLib.WAD);
     _costFactorAtFullUtilization = bound(_costFactorAtFullUtilization, 0, FixedPointMathLib.WAD);
-    _cancellationPenalty = bound(_cancellationPenalty, 0, FixedPointMathLib.WAD);
 
-    address _existingAddress = factory.getModel(     
+    address _existingAddress = factory.getModel(
       _kink,
       _costFactorAtZeroUtilization,
       _costFactorAtKinkUtilization,
-      _costFactorAtFullUtilization,
-      _cancellationPenalty
+      _costFactorAtFullUtilization
     );
     assertEq(_existingAddress, address(0));
 
@@ -50,12 +46,11 @@ contract CostModelJumpRateFactoryTest is Test, CostModelJumpRateFactory {
       _kink,
       _costFactorAtZeroUtilization,
       _costFactorAtKinkUtilization,
-      _costFactorAtFullUtilization,
-      _cancellationPenalty
+      _costFactorAtFullUtilization
     );
 
     address _addr = Create2.computeCreate2Address(
-      type(CostModelJumpRate).creationCode, 
+      type(CostModelJumpRate).creationCode,
       _costModelConstructorArgs,
       address(factory),
       keccak256("0")
@@ -63,40 +58,36 @@ contract CostModelJumpRateFactoryTest is Test, CostModelJumpRateFactory {
 
     vm.expectEmit(true, false, false, true);
     emit DeployedCostModelJumpRate(
-      _addr, 
+      _addr,
       _kink,
       _costFactorAtZeroUtilization,
       _costFactorAtKinkUtilization,
-      _costFactorAtFullUtilization,
-      _cancellationPenalty
+      _costFactorAtFullUtilization
     );
 
     address _result = address(
-      factory.deployModel(      
+      factory.deployModel(
         _kink,
         _costFactorAtZeroUtilization,
         _costFactorAtKinkUtilization,
-        _costFactorAtFullUtilization,
-        _cancellationPenalty
+        _costFactorAtFullUtilization
       )
     );
-    _existingAddress = factory.getModel(     
+    _existingAddress = factory.getModel(
       _kink,
       _costFactorAtZeroUtilization,
       _costFactorAtKinkUtilization,
-      _costFactorAtFullUtilization,
-      _cancellationPenalty
+      _costFactorAtFullUtilization
     );
     assertEq(_result, _existingAddress);
 
     // Trying to deploy again should result in revert
     vm.expectRevert();
-    factory.deployModel(      
+    factory.deployModel(
       _kink,
       _costFactorAtZeroUtilization,
       _costFactorAtKinkUtilization,
-      _costFactorAtFullUtilization,
-      _cancellationPenalty
+      _costFactorAtFullUtilization
     );
   }
 }

--- a/test/utils/MockCostModelJumpRate.sol
+++ b/test/utils/MockCostModelJumpRate.sol
@@ -9,14 +9,12 @@ contract MockCostModelJumpRate is CostModelJumpRate {
     uint256 _kink,
     uint256 _rateAtZeroUtilization,
     uint256 _rateAtKinkUtilization,
-    uint256 _rateAtFullUtilization,
-    uint256 _cancellationPenalty
+    uint256 _rateAtFullUtilization
   ) CostModelJumpRate(
     _kink,
     _rateAtZeroUtilization,
     _rateAtKinkUtilization,
-    _rateAtFullUtilization,
-    _cancellationPenalty
+    _rateAtFullUtilization
   ) {}
 
   function areaUnderCurve(


### PR DESCRIPTION
moving the penalty to be set in market config in the protocol instead of the jump rate model