### PR TITLE
Add/fix deploy scripts for dynamic level factory

### DIFF
--- a/script/DeployCostModelDynamicLevel.s.sol
+++ b/script/DeployCostModelDynamicLevel.s.sol
@@ -19,13 +19,13 @@ import "src/CostModelDynamicLevelFactory.sol";
  *
  * # In a separate terminal, perform a dry run the script.
  * forge script script/DeployCostModelDynamicLevel.s.sol \
- *   --sig "run(string)" "deploy-cost-model-jump-rate-<test or production>"
+ *   --sig "run(string)" "deploy-cost-model-dynamic-level-<test or production>"
  *   --rpc-url "http://127.0.0.1:8545" \
  *   -vvvv
  *
  * # Or, to broadcast a transaction.
  * forge script script/DeployCostModelDynamicLevel.s.sol \
- *   --sig "run(string)" "deploy-cost-model-jump-rate-<test or production>"
+ *   --sig "run(string)" "deploy-cost-model-dynamic-level-<test or production>"
  *   --rpc-url "http://127.0.0.1:8545" \
  *   --private-key $OWNER_PRIVATE_KEY \
  *   --broadcast \
@@ -75,34 +75,18 @@ contract DeployCostModelDynamicLevel is ScriptUtils {
         console2.log("    costFactorInOptimalZone", metadata_.costFactorInOptimalZone);
         console2.log("    optimalZoneRate", metadata_.optimalZoneRate);
 
-        address availableModel_ = factory.getModel(
-            metadata_.uLow,
-            metadata_.uHigh,
-            metadata_.costFactorAtZeroUtilization,
-            metadata_.costFactorAtFullUtilization,
-            metadata_.costFactorInOptimalZone,
-            metadata_.optimalZoneRate
+        vm.broadcast();
+        address deployedModel_ = address(
+            factory.deployModel(
+                metadata_.uLow,
+                metadata_.uHigh,
+                metadata_.costFactorAtZeroUtilization,
+                metadata_.costFactorAtFullUtilization,
+                metadata_.costFactorInOptimalZone,
+                metadata_.optimalZoneRate
+            )
         );
-
-        if (availableModel_ == address(0)) {
-            vm.broadcast();
-            availableModel_ = address(
-                factory.deployModel(
-                    metadata_.uLow,
-                    metadata_.uHigh,
-                    metadata_.costFactorAtZeroUtilization,
-                    metadata_.costFactorAtFullUtilization,
-                    metadata_.costFactorInOptimalZone,
-                    metadata_.optimalZoneRate
-                )
-            );
-            console2.log("New CostModelDynamicLevel deployed");
-        } else {
-            // A CostModelDynamicLevel exactly like the one you wanted already exists!
-            // Since models can be re-used, there's no need to deploy a new one.
-            console2.log("Found existing CostModelDynamicLevel with specified configs.");
-        }
-
-        console2.log("Your CostModelDynamicLevel is available at this address:", availableModel_);
+        console2.log("New CostModelDynamicLevel deployed");
+        console2.log("Your CostModelDynamicLevel is available at this address:", deployedModel_);
     }
 }

--- a/script/DeployModelFactories.s.sol
+++ b/script/DeployModelFactories.s.sol
@@ -3,49 +3,54 @@ pragma solidity 0.8.18;
 
 import "forge-std/Script.sol";
 import "src/CostModelJumpRateFactory.sol";
+import "src/CostModelDynamicLevelFactory.sol";
 import "src/DripDecayModelConstantFactory.sol";
 
 /**
-  * @notice Purpose: Local deploy, testing, and production.
-  *
-  * This script deploys the Model Factory contracts.
-  * Before executing, the configuration section in the script should be updated.
-  *
-  * To run this script:
-  *
-  * ```sh
-  * # Start anvil, forking from the current state of the desired chain.
-  * anvil --fork-url $OPTIMISM_RPC_URL
-  *
-  * # In a separate terminal, perform a dry run of the script.
-  * forge script script/DeployModelFactories.s.sol \
-  *   --rpc-url "http://127.0.0.1:8545" \
-  *   -vvvv
-  *
-  * # Or, to broadcast a transaction.
-  * forge script script/DeployModelFactories.s.sol \
-  *   --rpc-url "http://127.0.0.1:8545" \
-  *   --private-key $OWNER_PRIVATE_KEY \
-  *   --broadcast \
-  *   -vvvv
-  * ```
+ * @notice Purpose: Local deploy, testing, and production.
+ *
+ * This script deploys the Model Factory contracts.
+ * Before executing, the configuration section in the script should be updated.
+ *
+ * To run this script:
+ *
+ * ```sh
+ * # Start anvil, forking from the current state of the desired chain.
+ * anvil --fork-url $OPTIMISM_RPC_URL
+ *
+ * # In a separate terminal, perform a dry run of the script.
+ * forge script script/DeployModelFactories.s.sol \
+ *   --rpc-url "http://127.0.0.1:8545" \
+ *   -vvvv
+ *
+ * # Or, to broadcast a transaction.
+ * forge script script/DeployModelFactories.s.sol \
+ *   --rpc-url "http://127.0.0.1:8545" \
+ *   --private-key $OWNER_PRIVATE_KEY \
+ *   --broadcast \
+ *   -vvvv
+ * ```
  */
 contract DeployModelFactories is Script {
+    /// @notice Deploys all the Model Factory contracts
+    function run() public {
+        console2.log("Deploying Cozy V2 Model Factories...");
 
-  /// @notice Deploys all the Model Factory contracts
-  function run() public {
-    console2.log("Deploying Cozy V2 Model Factories...");
+        console2.log("  Deploying CostModelJumpRateFactory...");
+        vm.broadcast();
+        address costModelFactory = address(new CostModelJumpRateFactory());
+        console2.log("  CostModelJumpRateFactory deployed,", costModelFactory);
 
-    console2.log("  Deploying CostModelJumpRateFactory...");
-    vm.broadcast();
-    address costModelFactory = address(new CostModelJumpRateFactory());
-    console2.log("  CostModelJumpRateFactory deployed,", costModelFactory);
+        console2.log("  Deploying CostModelDynamicLevelFactory...");
+        vm.broadcast();
+        address costModelDynamicLevelFactory = address(new CostModelDynamicLevelFactory());
+        console2.log("  CostModelDynamicLevelFactory deployed,", costModelDynamicLevelFactory);
 
-    console2.log("  Deploying DripDecayModelConstantFactory...");
-    vm.broadcast();
-    address dripDecayModelFactory = address(new DripDecayModelConstantFactory());
-    console2.log("  DripDecayModelConstantFactory deployed,", dripDecayModelFactory);
+        console2.log("  Deploying DripDecayModelConstantFactory...");
+        vm.broadcast();
+        address dripDecayModelFactory = address(new DripDecayModelConstantFactory());
+        console2.log("  DripDecayModelConstantFactory deployed,", dripDecayModelFactory);
 
-    console2.log("Finished deploying Cozy V2 Model Factories");
-  }
+        console2.log("Finished deploying Cozy V2 Model Factories");
+    }
 }

--- a/src/CostModelDynamicLevelFactory.sol
+++ b/src/CostModelDynamicLevelFactory.sol
@@ -22,9 +22,7 @@ contract CostModelDynamicLevelFactory is BaseModelFactory {
 
     /// @notice Deploys a CostModelDynamicLevel contract and emits a
     /// DeployedCostModelDynamicLevel event that indicates what the params from the deployment are.
-    /// This address is then cached inside the isDeployed mapping. See CostModelDynamicLevel
-    /// constructor for more info about the input parameters.
-    /// @return model_ which has an address that is deterministic with the input parameters.
+    /// @return model_ which has an address.
     function deployModel(
         uint256 uLow_,
         uint256 uHigh_,
@@ -33,7 +31,7 @@ contract CostModelDynamicLevelFactory is BaseModelFactory {
         uint256 costFactorInOptimalZone_,
         uint256 optimalZoneRate_
     ) external returns (CostModelDynamicLevel model_) {
-        model_ = new CostModelDynamicLevel{salt: DEFAULT_SALT}({
+        model_ = new CostModelDynamicLevel({
           uLow_: uLow_,
           uHigh_: uHigh_,
           costFactorAtZeroUtilization_: costFactorAtZeroUtilization_,
@@ -42,8 +40,6 @@ contract CostModelDynamicLevelFactory is BaseModelFactory {
           optimalZoneRate_: optimalZoneRate_
         }
     );
-        isDeployed[address(model_)] = true;
-
         emit DeployedCostModelDynamicLevel(
             address(model_),
             uLow_,
@@ -53,30 +49,5 @@ contract CostModelDynamicLevelFactory is BaseModelFactory {
             costFactorInOptimalZone_,
             optimalZoneRate_
             );
-    }
-
-    /// @return The address where the model is deployed, or address(0) if it isn't deployed.
-    function getModel(
-        uint256 uLow_,
-        uint256 uHigh_,
-        uint256 costFactorAtZeroUtilization_,
-        uint256 costFactorAtFullUtilization_,
-        uint256 costFactorInOptimalZone_,
-        uint256 optimalZoneRate_
-    ) external view returns (address) {
-        bytes memory costModelConstructorArgs_ = abi.encode(
-            uLow_,
-            uHigh_,
-            costFactorAtZeroUtilization_,
-            costFactorAtFullUtilization_,
-            costFactorInOptimalZone_,
-            optimalZoneRate_
-        );
-
-        address addr_ = Create2.computeCreate2Address(
-            type(CostModelDynamicLevel).creationCode, costModelConstructorArgs_, address(this), DEFAULT_SALT
-        );
-
-        return isDeployed[addr_] ? addr_ : address(0);
     }
 }


### PR DESCRIPTION
Adds dynamic level factory to the deploy factories scripts.

Also fixes the dynamic level factory. We do not want to use a deterministic address as a function of the parameters, because the dynamic level cost model has updateable state. So, two dynamic level cost models with the same parameters can return different cost factors because one was started later than the other.