### PR TITLE
Change get storage params visibility

### DIFF
--- a/src/CostModelDynamicLevel.sol
+++ b/src/CostModelDynamicLevel.sol
@@ -100,7 +100,7 @@ contract CostModelDynamicLevel is ICostModel {
     if (toUtilization_ < fromUtilization_) revert InvalidUtilization();
     if (toUtilization_ > FULL_UTILIZATION) revert InvalidUtilization();
 
-    (uint256 costFactorInOptimalZone_,) = _getUpdatedStorageParams(block.timestamp, fromUtilization_);
+    (uint256 costFactorInOptimalZone_,) = getUpdatedStorageParams(block.timestamp, fromUtilization_);
 
     if (fromUtilization_ == toUtilization_) {
       return _pointOnCurve(costFactorInOptimalZone_, toUtilization_);
@@ -128,7 +128,7 @@ contract CostModelDynamicLevel is ICostModel {
     if (fromUtilization_ < toUtilization_) revert InvalidUtilization();
     if (fromUtilization_ == toUtilization_) return 0;
 
-    (uint256 costFactorInOptimalZone_,) = _getUpdatedStorageParams(block.timestamp, fromUtilization_);
+    (uint256 costFactorInOptimalZone_,) = getUpdatedStorageParams(block.timestamp, fromUtilization_);
 
     // Formula is: (area-under-return-interval / total-area-under-utilization-to-zero).
     // But we do all multiplication first so that we avoid precision loss.
@@ -250,8 +250,8 @@ contract CostModelDynamicLevel is ICostModel {
   /// `lastUpdateTime`.
   /// @param currentTime_ Current timestamp.
   /// @param utilization_ Current utilization.
-  function _getUpdatedStorageParams(uint256 currentTime_, uint256 utilization_)
-    internal
+  function getUpdatedStorageParams(uint256 currentTime_, uint256 utilization_)
+    public
     view
     returns (uint256 newCostFactorInOptimalZone_, uint256 newLastUpdateTime_)
   {
@@ -263,7 +263,7 @@ contract CostModelDynamicLevel is ICostModel {
 
   /// @dev Called by the Cozy protocol to update the model's storage variables.
   function update(uint256 utilization_, uint256 newUtilization_) external onlySet {
-    (costFactorInOptimalZone, lastUpdateTime) = _getUpdatedStorageParams(block.timestamp, newUtilization_);
+    (costFactorInOptimalZone, lastUpdateTime) = getUpdatedStorageParams(block.timestamp, newUtilization_);
     emit UpdatedDynamicLevelModelParameters(costFactorInOptimalZone, lastUpdateTime);
   }
 

--- a/test/CostModelDynamicLevel.t.sol
+++ b/test/CostModelDynamicLevel.t.sol
@@ -6,7 +6,6 @@ import {TestBase} from "test/utils/TestBase.sol";
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 import {ICostModel} from "src/interfaces/ICostModel.sol";
 import {MockCostModelDynamicLevel, CostModelDynamicLevel} from "test/utils/MockCostModelDynamicLevel.sol";
-import "forge-std/console2.sol";
 
 contract CostModelSetup is TestBase {
   using FixedPointMathLib for uint256;

--- a/test/utils/MockCostModelDynamicLevel.sol
+++ b/test/utils/MockCostModelDynamicLevel.sol
@@ -29,8 +29,4 @@ contract MockCostModelDynamicLevel is CostModelDynamicLevel {
   {
     return _areaUnderCurve(intervalLowPoint_, intervalHighPoint_, costFactorInOptimalZone_);
   }
-
-  function getUpdatedStorageParams(uint256 currentTime_, uint256 utilization_) public view returns (uint256, uint256) {
-    return _getUpdatedStorageParams(currentTime_, utilization_);
-  }
 }


### PR DESCRIPTION
I changed the visibility of `_getUpdatedStorageParams` to public so we can query it from the frontend and make our graphs move over time.

Also, added a few more tests to ensure the `_getUpdatedStorageParams` computation matches what the storage variables end up being set to when you call `update`.

Fixes ENG-1123.